### PR TITLE
Fix AR page back navigation

### DIFF
--- a/pages/ar.js
+++ b/pages/ar.js
@@ -8,9 +8,10 @@ const RealisticARPreview = dynamic(
 );
 
 export default function ARPage() {
-  const { query } = useRouter();
-  const { image } = query;           // passed as .../ar?image=<url>
+  const router = useRouter();
+  const { image } = router.query; // passed as .../ar?image=<url>
+
   return image ? (
-    <RealisticARPreview imageUrl={image} onClose={() => history.back()} />
+    <RealisticARPreview imageUrl={image} onClose={() => router.back()} />
   ) : null;
 }


### PR DESCRIPTION
## Summary
- fix AR page to use Next.js router for back navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684059bd3fd08331a8c8f654f9d03641