### PR TITLE
Fix camera switch and options overlay in AR preview

### DIFF
--- a/components/RealisticARPreview/RealisticARPreview.js
+++ b/components/RealisticARPreview/RealisticARPreview.js
@@ -296,6 +296,31 @@ useEffect(() => {
     }
   };
 }, []); // Remove all dependencies to run only once
+
+// Restart camera when facing mode changes after initialization
+useEffect(() => {
+  if (!initializedRef.current) return;
+
+  let cancelled = false;
+  const restart = async () => {
+    try {
+      stopCamera();
+      const { width, height } = await startCamera();
+      if (!cancelled && canvasRef.current) {
+        canvasRef.current.width = width;
+        canvasRef.current.height = height;
+      }
+    } catch (e) {
+      console.error('Camera switch error:', e);
+      if (!cancelled) setError(e.message || 'Failed to switch camera');
+    }
+  };
+
+  restart();
+  return () => {
+    cancelled = true;
+  };
+}, [settings.facing]);
   // Drag handlers
   const handleDragStart = (e) => {
     e.preventDefault();
@@ -422,6 +447,7 @@ useEffect(() => {
           }))
         }
         onShowAdvanced={() => setShowAdvanced((v) => !v)}
+        isAdvancedVisible={showAdvanced}
         onClose={onClose}
         onReset={() =>
           setSettings({

--- a/components/RealisticARPreview/components/ARControls.js
+++ b/components/RealisticARPreview/components/ARControls.js
@@ -13,7 +13,8 @@ export const ARControls = ({
   onReset,
   onCapture,
   onScaleChange,
-  onBodyPartChange
+  onBodyPartChange,
+  isAdvancedVisible
 }) => {
   // Format detected parts for display
   const getDetectedPartsInfo = () => {
@@ -77,13 +78,15 @@ export const ARControls = ({
               <SwitchCamera className="w-5 h-5" />
             </button>
 
-            <button
-              onClick={onShowAdvanced}
-              className="p-2 bg-white/10 backdrop-blur-md rounded-full text-white hover:bg-white/20 transition-all"
-              title="Settings"
-            >
-              <Sliders className="w-5 h-5" />
-            </button>
+            {!isAdvancedVisible && (
+              <button
+                onClick={onShowAdvanced}
+                className="p-2 bg-white/10 backdrop-blur-md rounded-full text-white hover:bg-white/20 transition-all"
+                title="Settings"
+              >
+                <Sliders className="w-5 h-5" />
+              </button>
+            )}
 
             {/* Close button - make it more prominent */}
             <button


### PR DESCRIPTION
## Summary
- restart camera when switching between front/back view
- hide the Settings button while advanced options are visible

## Testing
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68406f1828388331b6ecfae72142c651