### PR TITLE
Enhance auto detection

### DIFF
--- a/components/RealisticARPreview/RealisticARPreview.js
+++ b/components/RealisticARPreview/RealisticARPreview.js
@@ -141,6 +141,7 @@ export default function RealisticARPreview({ imageUrl, design, onClose }) {
           bodyPart: settings.bodyPart,
           detectedParts,
           landmarks,
+          segmentationMask: results.segmentationMask,
           dimensions: { width, height },
           settings,
           design


### PR DESCRIPTION
## Summary
- compute per-body-part confidence scores using landmark visibility and segmentation mask coverage
- refine orientation detection with world landmarks
- allow adaptive landmark visibility thresholds
- pass segmentation mask to tattoo transform logic

## Testing
- `npm run lint` *(fails: prompts interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68407ca99a348331b76df9a348207595