### PR TITLE
Add tattoo mesh warping and improve masking

### DIFF
--- a/components/RealisticARPreview/RealisticARPreview.js
+++ b/components/RealisticARPreview/RealisticARPreview.js
@@ -11,6 +11,7 @@ import { ErrorDisplay }      from './components/ErrorDisplay';
 
 import { calculateTattooTransform }  from './utils/bodyPartDetection';
 import { compositeWithSegmentation } from './utils/imageProcessing';
+import { warpToBody }                from './utils/warpToBody';
 import { DEFAULTS }                  from './utils/constants';
 
 import { Move, Loader2, Sliders } from 'lucide-react';
@@ -167,6 +168,8 @@ export default function RealisticARPreview({ imageUrl, design, onClose }) {
           }
 
           updateMesh(transform);
+          // Bend plane geometry to match body curvature
+          warpToBody({ mesh, bodyPart: settings.bodyPart, landmarks });
 
           if (renderer.setClearColor) renderer.setClearColor(0x000000, 0);
           if (renderer.clear) renderer.clear();

--- a/components/RealisticARPreview/hooks/useThreeScene.js
+++ b/components/RealisticARPreview/hooks/useThreeScene.js
@@ -158,7 +158,8 @@ export const useThreeScene = (imageUrl) => {
     dirLight.position.set(0, 1, 1);
     sceneRef.current.add(dirLight);
 
-    const geometry = new THREE.PlaneGeometry(1, 1);
+    // Use a subdivided plane so vertices can be warped to match body curvature
+    const geometry = new THREE.PlaneGeometry(1, 1, 20, 20);
     const material = new THREE.MeshStandardMaterial({
       transparent: true,
       side: THREE.DoubleSide,

--- a/components/RealisticARPreview/utils/imageProcessing.js
+++ b/components/RealisticARPreview/utils/imageProcessing.js
@@ -13,13 +13,19 @@ export const compositeWithSegmentation = ({
     tempCanvas.width = width;
     tempCanvas.height = height;
     const tempCtx = tempCanvas.getContext('2d');
-    
+
+    // Clear previous frame data
+    tempCtx.clearRect(0, 0, width, height);
+    ctx.clearRect(0, 0, width, height);
+
     // Draw three.js render
     tempCtx.drawImage(threeCanvas, 0, 0);
-    
-    // Apply segmentation mask
+
+    // Apply segmentation mask with slight blur to soften edges
+    tempCtx.filter = 'blur(2px)';
     tempCtx.globalCompositeOperation = 'destination-in';
     tempCtx.drawImage(segmentationMask, 0, 0, width, height);
+    tempCtx.filter = 'none';
     
     // Draw masked result to main canvas
     ctx.globalCompositeOperation = blendMode;

--- a/components/RealisticARPreview/utils/warpToBody.js
+++ b/components/RealisticARPreview/utils/warpToBody.js
@@ -1,0 +1,60 @@
+import * as THREE from 'three';
+
+/**
+ * Bend the plane mesh so the tattoo follows the curvature of the body.
+ * This is a lightweight approximation that adjusts vertex Z positions
+ * based on the angle between adjacent body landmarks.
+ */
+export const warpToBody = ({ mesh, bodyPart, landmarks }) => {
+  if (!mesh || !mesh.geometry) return;
+
+  const geom = mesh.geometry;
+
+  // Ensure geometry has enough segments to bend
+  if (geom.parameters.widthSegments < 4 || geom.parameters.heightSegments < 4) {
+    const { width = 1, height = 1 } = geom.parameters;
+    mesh.geometry.dispose();
+    mesh.geometry = new THREE.PlaneGeometry(width, height, 20, 20);
+  }
+
+  const positions = mesh.geometry.attributes.position;
+  const count = positions.count;
+
+  // Determine bend amount based on landmark angles
+  let curvature = 0;
+  const get = (k) => landmarks?.[k];
+
+  if (bodyPart?.includes('arm')) {
+    const side = bodyPart.startsWith('left') ? 'left' : 'right';
+    const shoulder = get(`${side}Shoulder`);
+    const elbow = get(`${side}Elbow`);
+    const wrist = get(`${side}Wrist`);
+    if (shoulder && elbow && wrist) {
+      const v1 = new THREE.Vector3(shoulder.x - elbow.x, shoulder.y - elbow.y, (shoulder.z || 0) - (elbow.z || 0));
+      const v2 = new THREE.Vector3(wrist.x - elbow.x, wrist.y - elbow.y, (wrist.z || 0) - (elbow.z || 0));
+      curvature = v1.angleTo(v2) / Math.PI; // fraction of 180deg
+    }
+  } else if (bodyPart?.includes('leg')) {
+    const side = bodyPart.startsWith('left') ? 'left' : 'right';
+    const hip = get(`${side}Hip`);
+    const knee = get(`${side}Knee`);
+    const ankle = get(`${side}Ankle`);
+    if (hip && knee && ankle) {
+      const v1 = new THREE.Vector3(hip.x - knee.x, hip.y - knee.y, (hip.z || 0) - (knee.z || 0));
+      const v2 = new THREE.Vector3(ankle.x - knee.x, ankle.y - knee.y, (ankle.z || 0) - (knee.z || 0));
+      curvature = v1.angleTo(v2) / Math.PI;
+    }
+  } else {
+    curvature = 0.2; // small default bend
+  }
+
+  for (let i = 0; i < count; i++) {
+    const x = positions.getX(i);
+    const y = positions.getY(i);
+    const z = Math.sin((y + 0.5) * Math.PI) * curvature * mesh.scale.y * 0.3;
+    positions.setZ(i, z);
+  }
+
+  positions.needsUpdate = true;
+  mesh.geometry.computeVertexNormals();
+};


### PR DESCRIPTION
## Summary
- allow plane geometry deformation by subdividing mesh
- create `warpToBody` util to warp mesh according to landmarks
- hook warping step into `RealisticARPreview`
- clear segmentation canvas every frame and blur mask edges

## Testing
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68419903a740833187ae8f92143de4ef