### PR TITLE
Fix AR preview dynamic import

### DIFF
--- a/components/RealisticARPreview/RealisticARPreview.js
+++ b/components/RealisticARPreview/RealisticARPreview.js
@@ -1,25 +1,34 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useCamera }        from './hooks/useCamera';
-import { useMediaPipe }     from './hooks/useMediaPipe';
-import { usePoseDetection } from './hooks/usePoseDetection';
-import { useThreeScene }    from './hooks/useThreeScene';
 
-import { ARControls }        from './components/ARControls';
-import { AdvancedControls }  from './components/AdvancedControls';
-import { DebugInfo }         from './components/DebugInfo';
-import { ErrorDisplay }      from './components/ErrorDisplay';
-
-import { calculateTattooTransform }  from './utils/bodyPartDetection';
-import { compositeWithSegmentation } from './utils/imageProcessing';
-import { warpToBody }                from './utils/warpToBody';
-import { DEFAULTS }                  from './utils/constants';
-
+// External libraries
 import { Move, Loader2, Sliders } from 'lucide-react';
 import { motion } from 'framer-motion';
+
+// Internal hooks (order matters!)
+import { useCamera } from './hooks/useCamera';
+import { useMediaPipe } from './hooks/useMediaPipe';
+import { usePoseDetection } from './hooks/usePoseDetection';
+import { useThreeScene } from './hooks/useThreeScene';
+
+// Components
+import { ARControls } from './components/ARControls';
+import { AdvancedControls } from './components/AdvancedControls';
+import { DebugInfo } from './components/DebugInfo';
+import { ErrorDisplay } from './components/ErrorDisplay';
+
+// Utils (order matters!)
+import { DEFAULTS } from './utils/constants';
+import { calculateTattooTransform } from './utils/bodyPartDetection';
+import { compositeWithSegmentation } from './utils/imageProcessing';
+import { warpToBody } from './utils/warpToBody';
 import { SegmentationEnhancer } from './utils/segmentationEnhancer';
 
+// Ensure we're in browser environment before creating instances
+const isBrowser = typeof window !== 'undefined';
+
 export default function RealisticARPreview({ imageUrl, design, onClose }) {
-  if (typeof window === 'undefined') {
+  // Add browser check
+  if (!isBrowser) {
     return null;
   }
 
@@ -39,7 +48,7 @@ export default function RealisticARPreview({ imageUrl, design, onClose }) {
   const enhancedSegmentationRef = useRef(null);
 
   // Initialize segmentation enhancer immediately
-  if (!segmentationEnhancerRef.current && typeof window !== 'undefined') {
+  if (!segmentationEnhancerRef.current && isBrowser) {
     segmentationEnhancerRef.current = new SegmentationEnhancer();
   }
 

--- a/components/RealisticARPreview/index.js
+++ b/components/RealisticARPreview/index.js
@@ -1,2 +1,2 @@
 // components/RealisticARPreview/index.js
-export { default } from './RealisticARPreview';   // <-- or './ARPreview'
+export { default } from './ARPreviewDynamic';

--- a/components/RealisticARPreview/utils/bodyMeshGenerator.js
+++ b/components/RealisticARPreview/utils/bodyMeshGenerator.js
@@ -1,6 +1,11 @@
 // components/RealisticARPreview/utils/bodyMeshGenerator.js
 import * as THREE from 'three';
 
+// Add a check for browser environment
+if (typeof window === 'undefined') {
+  global.THREE = THREE;
+}
+
 // Parametric mesh generators for different body parts
 export class BodyMeshGenerator {
   constructor() {


### PR DESCRIPTION
## Summary
- export AR preview from a dynamic wrapper
- reorder imports and add browser checks for AR preview
- ensure BodyMeshGenerator works when run outside the browser

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6841e9c6e850833190b7361fb04d6fd5